### PR TITLE
Changed IP client detection for Apache 2.4

### DIFF
--- a/mod_ip2location.c
+++ b/mod_ip2location.c
@@ -79,7 +79,7 @@ static int ip2location_post_read_request(request_rec *r) {
 		}
 		else {
 			#if (((AP_SERVER_MAJORVERSION_NUMBER == 2) && (AP_SERVER_MINORVERSION_NUMBER >= 4)) || (AP_SERVER_MAJORVERSION_NUMBER > 2))
-				ipaddr = r->connection->client_ip;
+				ipaddr = r->useragent_ip;
 			#else
 				ipaddr = r->connection->remote_ip;
 			#endif
@@ -87,7 +87,7 @@ static int ip2location_post_read_request(request_rec *r) {
 	}
 	else{
 		#if (((AP_SERVER_MAJORVERSION_NUMBER == 2) && (AP_SERVER_MINORVERSION_NUMBER >= 4)) || (AP_SERVER_MAJORVERSION_NUMBER > 2))
-			ipaddr = r->connection->client_ip;
+			ipaddr = r->useragent_ip;
 		#else	
 			ipaddr = r->connection->remote_ip;
 		#endif	
@@ -97,6 +97,7 @@ static int ip2location_post_read_request(request_rec *r) {
 
 	if(record) {
 		if(config->setMode & ENV_SET_MODE) {
+			apr_table_set(r->subprocess_env, "IP2LOCATION_IP", ipaddr);
 			apr_table_set(r->subprocess_env, "IP2LOCATION_COUNTRY_SHORT", record->country_short); 
 			apr_table_set(r->subprocess_env, "IP2LOCATION_COUNTRY_LONG", record->country_long); 
 			apr_table_set(r->subprocess_env, "IP2LOCATION_REGION", record->region); 
@@ -122,6 +123,7 @@ static int ip2location_post_read_request(request_rec *r) {
 			apr_table_set(r->subprocess_env, "IP2LOCATION_USAGETYPE", record->usagetype);
 		}
 		if(config->setMode & NOTES_SET_MODE) {
+			apr_table_set(r->notes, "IP2LOCATION_IP", ipaddr);
 			apr_table_set(r->notes, "IP2LOCATION_COUNTRY_SHORT", record->country_short); 
 			apr_table_set(r->notes, "IP2LOCATION_COUNTRY_LONG", record->country_long); 
 			apr_table_set(r->notes, "IP2LOCATION_REGION", record->region); 


### PR DESCRIPTION
-Using the updated 2.4 client IP address accessor per Apache documentation as referenced below.  In cases where mods like mod_remoteip are used this method will take advantage of the updated address set by mod_remoteip.  For other configurations the existing behavior is preserved where useragent_addr should be the same address as client_ip.

This change allows configurations that use mod_remoteip to set the client IP from a proxy header and treat it as if it is the client ip throughout the rest of processing.  In such a configuration IP2LocationDetectProxy can be On or Off.  In a configuration without this change the usage of mod_remoteip and its behavior either have to be disabled (affecting other things) or altered such that a new header is injected for this mod to find the IP in question.

-Added IP2LOCATION_IP env/note variable that will be set to the address used to perform the lookup.  This is useful in debugging and possibly logging.

https://httpd.apache.org/docs/2.4/ru/developer/new_api_2_4.html
---
conn_rec->remote_ip and conn_rec->remote_addr
These fields have been renamed in order to distinguish between the client IP address of the connection and the useragent IP address of the request (potentially overridden by a load balancer or proxy). References to either of these fields must be updated with one of the following options, as appropriate for the module:
-When you require the IP address of the user agent, which might be connected directly to the server, or might optionally be separated from the server by a transparent load balancer or proxy, use request_rec->useragent_ip and request_rec->useragent_addr.
-When you require the IP address of the client that is connected directly to the server, which might be the useragent or might be the load balancer or proxy itself, use conn_rec->client_ip and conn_rec->client_addr.
---